### PR TITLE
Fixing Logger's `WithNodeID` and `WithTerm`

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,5 +1,9 @@
 package logger
 
+import (
+	"github.com/jathurchan/raftlock/types"
+)
+
 // Logger defines an interface for structured, context-aware logging used in a Raft implementation.
 //
 // All logging methods support structured output by accepting a message and a variadic list of key-value pairs.
@@ -56,10 +60,10 @@ type Logger interface {
 
 	// WithNodeID adds a node identifier to the logger's context.
 	// Typically used to distinguish logs from different Raft nodes.
-	WithNodeID(id int) Logger
+	WithNodeID(id types.NodeID) Logger
 
 	// WithTerm adds the current Raft term to the logger's context.
-	WithTerm(term uint64) Logger
+	WithTerm(term types.Term) Logger
 
 	// WithComponent adds a component label (e.g., "election", "rpc")
 	// used to categorize log output.

--- a/logger/noop_logger.go
+++ b/logger/noop_logger.go
@@ -1,5 +1,7 @@
 package logger
 
+import "github.com/jathurchan/raftlock/types"
+
 // NoOpLogger is a Logger implementation that silently discards all log messages.
 // It is useful for testing, benchmarking, or disabling logging entirely.
 // Each method can be optionally overridden for testing purposes.
@@ -50,10 +52,10 @@ func (l *NoOpLogger) Fatalw(msg string, keysAndValues ...any) {
 func (l *NoOpLogger) With(keysAndValues ...any) Logger { return l }
 
 // WithNodeID returns the same NoOpLogger; context is not stored.
-func (l *NoOpLogger) WithNodeID(id int) Logger { return l }
+func (l *NoOpLogger) WithNodeID(id types.NodeID) Logger { return l }
 
 // WithTerm returns the same NoOpLogger; context is not stored.
-func (l *NoOpLogger) WithTerm(term uint64) Logger { return l }
+func (l *NoOpLogger) WithTerm(term types.Term) Logger { return l }
 
 // WithComponent returns the same NoOpLogger; context is not stored.
 func (l *NoOpLogger) WithComponent(name string) Logger { return l }

--- a/logger/noop_logger_test.go
+++ b/logger/noop_logger_test.go
@@ -18,7 +18,7 @@ func TestNoOpLogger(t *testing.T) {
 	enriched := logger.With("key", "value")
 	enriched.Infow("enriched message")
 
-	nodeLogger := logger.WithNodeID(1)
+	nodeLogger := logger.WithNodeID("1")
 	nodeLogger.Infow("node message")
 
 	termLogger := logger.WithTerm(5)
@@ -28,6 +28,6 @@ func TestNoOpLogger(t *testing.T) {
 	compLogger.Infow("component message")
 
 	// Test chaining of context enrichment methods
-	chainedLogger := logger.WithNodeID(1).WithTerm(5).WithComponent("test").With("key", "value")
+	chainedLogger := logger.WithNodeID("1").WithTerm(5).WithComponent("test").With("key", "value")
 	chainedLogger.Infow("chained message")
 }

--- a/logger/std_logger.go
+++ b/logger/std_logger.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"strings"
+
+	"github.com/jathurchan/raftlock/types"
 )
 
 // StdLogger implements the Logger interface using Go's standard log package.
@@ -105,12 +107,12 @@ func (l *StdLogger) With(kvs ...any) Logger {
 }
 
 // WithNodeID returns a new logger with a node identifier added to the context.
-func (l *StdLogger) WithNodeID(id int) Logger {
+func (l *StdLogger) WithNodeID(id types.NodeID) Logger {
 	return l.cloneWithContext(map[string]any{"node": id})
 }
 
 // WithTerm returns a new logger with the Raft term added to the context.
-func (l *StdLogger) WithTerm(term uint64) Logger {
+func (l *StdLogger) WithTerm(term types.Term) Logger {
 	return l.cloneWithContext(map[string]any{"term": term})
 }
 

--- a/logger/std_logger_test.go
+++ b/logger/std_logger_test.go
@@ -189,7 +189,7 @@ func TestStdLogger_ContextEnrichment(t *testing.T) {
 	logger := NewStdLogger()
 
 	// Test WithNodeID
-	nodeLogger := logger.WithNodeID(1)
+	nodeLogger := logger.WithNodeID("1")
 	nodeLogger.Infow("node message")
 	if !strings.Contains(buf.String(), "[INFO] node message") || !strings.Contains(buf.String(), "node=1") {
 		t.Errorf("Node log doesn't contain expected content: %s", buf.String())
@@ -213,7 +213,7 @@ func TestStdLogger_ContextEnrichment(t *testing.T) {
 	buf.Reset()
 
 	// Test chaining context methods
-	chainedLogger := logger.WithNodeID(1).WithTerm(5).WithComponent("rpc")
+	chainedLogger := logger.WithNodeID("1").WithTerm(5).WithComponent("rpc")
 	chainedLogger.Infow("chained message")
 	output := buf.String()
 	buf.Reset()
@@ -254,10 +254,10 @@ func TestStdLogger_ContextOverride(t *testing.T) {
 	logger := NewStdLogger()
 
 	// Create logger with initial context
-	nodeLogger := logger.WithNodeID(1)
+	nodeLogger := logger.WithNodeID("1")
 
 	// Override context with new values
-	newNodeLogger := nodeLogger.WithNodeID(2)
+	newNodeLogger := nodeLogger.WithNodeID("2")
 
 	// Check that original logger retains its context
 	nodeLogger.Infow("original node")
@@ -274,8 +274,8 @@ func TestStdLogger_ContextOverride(t *testing.T) {
 	buf.Reset()
 
 	// Test overriding multiple contexts
-	multiLogger := logger.WithNodeID(1).WithTerm(5)
-	updatedLogger := multiLogger.WithNodeID(2).WithTerm(6)
+	multiLogger := logger.WithNodeID("1").WithTerm(5)
+	updatedLogger := multiLogger.WithNodeID("2").WithTerm(6)
 
 	multiLogger.Infow("original multi")
 	output := buf.String()
@@ -301,7 +301,7 @@ func TestStdLogger_TemporaryContext(t *testing.T) {
 	log.SetOutput(&buf)
 	defer log.SetOutput(os.Stderr)
 
-	logger := NewStdLogger().WithNodeID(1)
+	logger := NewStdLogger().WithNodeID("1")
 
 	// Add temporary context for a single log entry
 	logger.With("latency", "150ms").Warnw("Slow response")


### PR DESCRIPTION
closes #40 